### PR TITLE
Adds: December 2022 Meeting notes

### DIFF
--- a/meetings/2022-12-08.md
+++ b/meetings/2022-12-08.md
@@ -51,7 +51,7 @@
       - We (USGS) can't use Zenodo anymore...
     - As a paper writer, it makes sense to have one citation for ISIS. Info should be in the paper (version, commit hash, etc.). For simplicity, less DOIs are better than more DOIs. Suggests that lower burden is the better approach. If the cost is low enough, do it, if not, consider not doing it.
     - Robin: Probably 45-60 minutes. Not excessive, but another step. Four times per year?
-    - Spicepy - people cite the global DOI. Citation aggregators spread out the references to the DOIs, then the maintainer(s) need to aggregate.
+    - SpiceyPy - people cite the global DOI. Citation aggregators spread out the references to the DOIs, then the maintainer(s) need to aggregate.
     - Questions of granularity.
     - DOIs are not in lock step with SemVer. These are for papers.
     - Kris: Does skipping the DOI eliminate a review?

--- a/meetings/2022-12-08.md
+++ b/meetings/2022-12-08.md
@@ -4,24 +4,84 @@
 
 ### Attending
 
--
+- Jay Laura
+- Kris Becker
+- Stuart Robbins
+- Audrie Fennema
+- Adam Paquette
+- Robin Fergason
+- Kelvin Rodriguez
+- Andrew Annex
+- Ross Beyer
 
 ## Agenda / Notes
 
 - Action Items from last month (None)
 - ASC Notification: ISIS 7.2 RC is being released.
+  - OS X / Linux builds are clean. Going to get the builds out, tested, and pushed. Should be out by Friday.
+  - Is the webpage (isis.astrogeology.usgs.gov) updated with each release (user documentation)?
+    - Yes, on a version by version. (Major.Minor)
+    - Was discussion about versioning. Not scheduled for work at this time.
+    - Please open an issue. Project wants to see and hear if this is an issue.
 - ASC Notification: rsync servers have been shutdown.
+  - Distribution of the ISIS data is now solely available via the rclone tools.
+  - Announcements to AstroDiscuss / DPS / PEN. Instructions are also included in the announcement.
+  - Effort to minimize the size of the download?
+    - Looking as been done to stop pulling zip and pdf files.
+    - Filtering file usage? 
+      - Kelvin: This is the plan.
+      - Kris: Has a filter file. Will post. Cuts ORex to < 1TB. Will post a gist on the issue Kelvin has open.
 - Discussion regarding how often to create a new DOI for ISIS releases
-        ISIS TC - every release
-        USGS software release policy - every major version only
-
+  - This came from the ISIS 7.2 release.
+  - ISIS TC - every release; would like to see a DOI for every release.
+  - USGS software release policy - every major version only.
+  - Project would like to generate DOIs only for major version increments.
+  - Concerns:
+    - From an end user perspective, doubts that new DOIs would be desirable for every version. Likely not to look for a new DOI. Would support updating the DOI as infrequently as is reasonable.
+      - Hypothetical: Publish a paper using 7.x this year, then another next year, unlikely to search for a new DOI. Likely to copy/paste an old DOI. Potentially have one DOI per version could lead to confusion.
+      - 
+    - Ross: DOIs are meant to precisely reference the version used for a task / project. If you want people to use versions that are not major releases, then you need a DOI for them.
+    - Hypothetical: Pull a DOI for 7.0. Does that DOI refer to anything under the 7.x umbrella? - No. 
+    - A DOI points to one publication (or one version), it does not point to a group of publications (versions).
+    - Hypothetical: If someone uses ISIS7.2 how do they credit that? What if the DOI points to 7.0? Onus is on the reader to spot the difference and then do something about it.
+    - Why is this coming up? Is it hard to mint DOIs? - No. It is just an extra step. It is above and beyond what is required by USGS.
+    - Discussion is good.
+    - Andrew: No strong feeling. On Zenodo (CERN data repo). The norm is one global DOI for the most recent release and then every version has its own DOI. 
+    - Disagree: Zenodo has an overall DOI, then an individual for each release. There is not a 7.0 that covers all 7.x. There is a global DOI and then one for each release.
+      - We (USGS) can't use Zenodo anymore...
+    - As a paper writer, it makes sense to have one citation for ISIS. Info should be in the paper (version, commit hash, etc.). For simplicity, less DOIs are better than more DOIs. Suggests that lower burden is the better approach. If the cost is low enough, do it, if not, consider not doing it.
+    - Robin: Probably 45-60 minutes. Not excessive, but another step. Four times per year?
+    - Spicepy - people cite the global DOI. Citation aggregators spread out the references to the DOIs, then the maintainer(s) need to aggregate.
+    - Questions of granularity.
+    - DOIs are not in lock step with SemVer. These are for papers.
+    - Kris: Does skipping the DOI eliminate a review?
+    - Robin: No, this does not change the USGS review process. The would change the frequency that USGS mints the DOIs.
+    - Will only having one DOI per major release lead to confusion about which version / DOI to use?
+    - Are there other USGS groups and what do they do?
+      - Policy is major release only.
+    - What are other best practice examples in the community?
+      - ASP has a DOI for every release (including daily releases). They are wired into Zenodo.
+    - Kris: Maybe one per release eliminates confusion and is more thorough.
+    - Motion for a lazy consensus?
+      - Kris: Have a DOI made for each release, including minor releases.
+      - Ross: Seconded.
+      - Question: Does this include bug versions? (e.g., 7.1.x)
+        - No.
+    - Jay: Does anyone object?
+      - No objections.
+      - The ISIS TC requests that the project mint a DOI for each major and minor version release.
+    - Stuart: Addendum - what he does as an end user does not change his thinking on the proposed. As a user, he will likely not seek out a new DOI.
+    - Assume that ASC will implement this recommendation and will bring any issues back to the TC if they arise.
 ## Discussions for next meeting
 
--
-
+- Velocity of releases. 
+  - Let's check the notes.
+  - ASC update on LTS.
+  - TC's role in community education re: ISIS not 3.
+- 
 ## Action Items
 
-- 
+- Look at notes re: Velocity
 
 ## Next Meeting
 

--- a/meetings/2023-01-12.md
+++ b/meetings/2023-01-12.md
@@ -1,0 +1,24 @@
+# ISIS TC Meeting January 12, 2023 @ 12PM PST / 1PM MST / 3PM EST
+
+## [Teams Link](https://teams.microsoft.com/dl/launcher/launcher.html?url=%2f_%23%2fl%2fmeetup-join%2f19%3ameeting_YWRkZjdiMGUtZWJlOC00OWMzLThlMTItZTk0Y2MyM2E1MWE0%40thread.v2%2f0%3fcontext%3d%257b%2522Tid%2522%253a%25220693b5ba-4b18-4d7b-9341-f32f400a5494%2522%252c%2522Oid%2522%253a%2522c27c6e98-e45a-45ff-aea5-7f10d6fe67c1%2522%257d%26anon%3dtrue&type=meetup-join&deeplinkId=e54b3969-3c7f-4efb-9cad-ee99cf639f86&directDl=true&msLaunch=true&enableMobilePage=true&suppressPrompt=true)
+
+### Attending
+
+- Velocity of releases. 
+- ASC update on LTS.(Jay)
+- TC's role in community education re: ISIS not 3.
+
+## Agenda / Notes
+
+- 
+## Discussions for next meeting
+
+
+- 
+## Action Items
+
+- 
+
+## Next Meeting
+
+- March 9th @ 1pm MST

--- a/meetings/2023-01-12.md
+++ b/meetings/2023-01-12.md
@@ -4,19 +4,17 @@
 
 ### Attending
 
+## Agenda / Notes
 - Velocity of releases. 
-- ASC update on LTS.(Jay)
+- ~ASC update on LTS.(Jay)~
+  - Removed from the agenda because work at the ASC is not scheduled to start until 1.9.2023.
 - TC's role in community education re: ISIS not 3.
 
-## Agenda / Notes
 
-- 
 ## Discussions for next meeting
-
-
 - 
-## Action Items
 
+## Action Items
 - 
 
 ## Next Meeting


### PR DESCRIPTION
This adds the meeting notes and stubs for January.

Also, please note that I changed the default branch from `master` to `main` for a myriad of reasons. In hindsight, I probably should have put this on the meeting agenda. If folks have concerns, I am happy to revert to `master` and get an issue open. Apologies that I clicked these changes and then considered that this should be a group decision!